### PR TITLE
Bump Monty STAC Extension version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2025-11-06
 
 ### Added
+
+- New dynamic correlation algorithms using STAC API and CQL2 filters [#33](https://github.com/IFRCGo/monty-stac-extension/pull/33)
 
 ### Changed
 
 - Updated taxonomy for 2025 UNDRR-ISC Hazard Information Profiles [#32](https://github.com/IFRCGo/monty-stac-extension/pull/32)
+- Deprecating static correlation_id in favor of dynamic STAC-based correlation [#33](https://github.com/IFRCGo/monty-stac-extension/pull/33)
 
 ### Fixed
 
@@ -84,5 +87,5 @@ Initial release of the Monty STAC Extension specification.
 - Some features may be subject to change based on community feedback
 - Additional sources may be added in future releases
 
-[Unreleased]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.0.0..HEAD
+[1.1.0]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.1.0
 [1.0.0]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Monty Extension Specification
 
 - **Title:** Monty
-- **Identifier:** <https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json>
+- **Identifier:** <https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json>
 - **Field Name Prefix:** monty
 - **Scope:** Item, Collection
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal

--- a/docs/model/sources/DesInventar/README.md
+++ b/docs/model/sources/DesInventar/README.md
@@ -145,10 +145,10 @@ Here is the mapping of fields from Desinventar XML to STAC event items:
 | [start_datetime](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#date-and-time) | fechano, fechames, fechadia                        | Start date of the event                                                                 |
 | [end_datetime](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#date-and-time)   | fechano, fechames, fechadia + [duracion]           | End date of the event                                                                   |
 | [title](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#item-properties)        | evento + lugar + date                              | Human-readable title combining event type and location                                  |
-| [monty:episode_number](https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#monty:episode_number)                     | 1                                                  | Set to 1 as Desinventar doesn't track episodes                                          |
-| [monty:country_codes](https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#monty:country_codes)                       | level0                                             | ISO3 code of the event country                                                          |
-| [monty:hazard_codes](https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#monty:hazard_codes)                         | [mapped from evento](#hazard-code-mapping)         | Hazard codes mapped from Desinventar event types (see mapping below)                    |
-| [monty:corr_id](https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#monty:corr_id)                                   | Generated                                          | Generated following the [event correlation](../../correlation_identifier.md) convention |
+| [monty:episode_number](https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#monty:episode_number)                     | 1                                                  | Set to 1 as Desinventar doesn't track episodes                                          |
+| [monty:country_codes](https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#monty:country_codes)                       | level0                                             | ISO3 code of the event country                                                          |
+| [monty:hazard_codes](https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#monty:hazard_codes)                         | [mapped from evento](#hazard-code-mapping)         | Hazard codes mapped from Desinventar event types (see mapping below)                    |
+| [monty:corr_id](https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#monty:corr_id)                                   | Generated                                          | Generated following the [event correlation](../../correlation_identifier.md) convention |
 
 #### Hazard Code Mapping
 
@@ -223,7 +223,7 @@ For each available impact metric in the Desinventar data, a separate impact item
 | ----------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------------------------- |
 | [id](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#id)                       | {level0}-{serial}-{metric} | Unique ID combining event serial and impact metric |
 | [title](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#item-properties) | {event title} - {metric}   | Title combining event name and impact type         |
-| [monty:impact_detail](https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#monty:impact_detail)                |                            | Object containing impact details                   |
+| [monty:impact_detail](https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#monty:impact_detail)                |                            | Object containing impact details                   |
 | monty:impact_detail.category                                                                                | From mapping table         | Impact category code                               |
 | monty:impact_detail.type                                                                                    | From mapping table         | Impact type code                                   |
 | monty:impact_detail.value                                                                                   | From Desinventar field     | Numeric impact value                               |

--- a/examples/desinventar-events/desinventar-events.json
+++ b/examples/desinventar-events/desinventar-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "desinventar-events",

--- a/examples/desinventar-events/grd-194.json
+++ b/examples/desinventar-events/grd-194.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "grd-194",
   "geometry": {

--- a/examples/desinventar-events/grd-200.json
+++ b/examples/desinventar-events/grd-200.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "grd-200",
   "geometry": {

--- a/examples/desinventar-impacts/desinventar-impacts.json
+++ b/examples/desinventar-impacts/desinventar-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "desinventar-impacts",

--- a/examples/desinventar-impacts/grd-200-deaths.json
+++ b/examples/desinventar-impacts/grd-200-deaths.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "desinventar-impact-200-deaths",
   "geometry": {

--- a/examples/emdat-events/2024-0796-ESP.json
+++ b/examples/emdat-events/2024-0796-ESP.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "emdat-event-2024-0796-ESP",
   "geometry": {

--- a/examples/emdat-events/emdat-events.json
+++ b/examples/emdat-events/emdat-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "emdat-events",

--- a/examples/emdat-hazards/emdat-hazards.json
+++ b/examples/emdat-hazards/emdat-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "emdat-hazards",

--- a/examples/emdat-impacts/emdat-impacts.json
+++ b/examples/emdat-impacts/emdat-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "emdat-impacts",

--- a/examples/gdacs-events/1102983-1.json
+++ b/examples/gdacs-events/1102983-1.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "1102983",

--- a/examples/gdacs-events/1102983-2.json
+++ b/examples/gdacs-events/1102983-2.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "1102983",

--- a/examples/gdacs-events/gdacs-events.json
+++ b/examples/gdacs-events/gdacs-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gdacs-events",

--- a/examples/gdacs-hazards/1102983-1.json
+++ b/examples/gdacs-hazards/1102983-1.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "1102983",

--- a/examples/gdacs-hazards/gdacs-hazards.json
+++ b/examples/gdacs-hazards/gdacs-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gdacs-hazards",

--- a/examples/gdacs-impacts/gdacs-impact-1102983-2-A-death-Spain-Andalusia.json
+++ b/examples/gdacs-impacts/gdacs-impact-1102983-2-A-death-Spain-Andalusia.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "gdacs-impact-1102983-2-A-death-Spain-Andalusia",
   "geometry": {

--- a/examples/gdacs-impacts/gdacs-impacts.json
+++ b/examples/gdacs-impacts/gdacs-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gdacs-impacts",

--- a/examples/gfd-events/gfd-events.json
+++ b/examples/gfd-events/gfd-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gfd-events",

--- a/examples/gfd-hazards/gfd-hazards.json
+++ b/examples/gfd-hazards/gfd-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gfd-hazards",

--- a/examples/gfd-impacts/gfd-impacts.json
+++ b/examples/gfd-impacts/gfd-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "gfd-impacts",

--- a/examples/glide-events/EQ-2008-000062-CHN.json
+++ b/examples/glide-events/EQ-2008-000062-CHN.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "EQ-2008-000062-CHN",

--- a/examples/glide-events/FL-2024-000199-ESP.json
+++ b/examples/glide-events/FL-2024-000199-ESP.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "glide-event-FL-2024-000199-ESP",
   "geometry": {

--- a/examples/glide-events/glide-events.json
+++ b/examples/glide-events/glide-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "glide-events",

--- a/examples/glide-hazards/FL-2024-000199-ESP.json
+++ b/examples/glide-hazards/FL-2024-000199-ESP.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "glide-hazard-FL-2024-000199-ESP",
   "geometry": {

--- a/examples/glide-hazards/glide-hazards.json
+++ b/examples/glide-hazards/glide-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "glide-hazards",

--- a/examples/ibtracs-events/2024178N09335.json
+++ b/examples/ibtracs-events/2024178N09335.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "2024178N09335",

--- a/examples/ibtracs-events/ibtracs-events.json
+++ b/examples/ibtracs-events/ibtracs-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "ibtracs-events",

--- a/examples/ibtracs-hazards/2024178N09335-hazard-20240626T000000Z.json
+++ b/examples/ibtracs-hazards/2024178N09335-hazard-20240626T000000Z.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "2024178N09335-hazard-20240626T000000Z",

--- a/examples/ibtracs-hazards/2024178N09335-hazard-20240629T000000Z.json
+++ b/examples/ibtracs-hazards/2024178N09335-hazard-20240629T000000Z.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "2024178N09335-hazard-20240629T000000Z",

--- a/examples/ibtracs-hazards/2024178N09335-hazard-20240702T000000Z.json
+++ b/examples/ibtracs-hazards/2024178N09335-hazard-20240702T000000Z.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "2024178N09335-hazard-20240702T000000Z",

--- a/examples/ibtracs-hazards/2024178N09335-hazard-20240708T000000Z.json
+++ b/examples/ibtracs-hazards/2024178N09335-hazard-20240708T000000Z.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "2024178N09335-hazard-20240708T000000Z",

--- a/examples/ibtracs-hazards/ibtracs-hazards.json
+++ b/examples/ibtracs-hazards/ibtracs-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "ibtracs-hazards",

--- a/examples/idmc-gidd-events/idmc-gidd-event-32145.json
+++ b/examples/idmc-gidd-events/idmc-gidd-event-32145.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "idmc-gidd-event-32145",

--- a/examples/idmc-gidd-events/idmc-gidd-events.json
+++ b/examples/idmc-gidd-events/idmc-gidd-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "idmc-gidd-events",

--- a/examples/idmc-gidd-impacts/idmc-gidd-impact-107479-displaced.json
+++ b/examples/idmc-gidd-impacts/idmc-gidd-impact-107479-displaced.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "idmc-gidd-impact-107479-displaced",
   "collection": "idmc-gidd-impacts",

--- a/examples/idmc-gidd-impacts/idmc-gidd-impact-107555-displaced.json
+++ b/examples/idmc-gidd-impacts/idmc-gidd-impact-107555-displaced.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "idmc-gidd-impact-107555-displaced",
   "collection": "idmc-gidd-impacts",

--- a/examples/idmc-gidd-impacts/idmc-gidd-impact-108364-displaced.json
+++ b/examples/idmc-gidd-impacts/idmc-gidd-impact-108364-displaced.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "idmc-gidd-impact-108364-displaced",
   "collection": "idmc-gidd-impacts",

--- a/examples/idmc-gidd-impacts/idmc-gidd-impacts.json
+++ b/examples/idmc-gidd-impacts/idmc-gidd-impacts.json
@@ -50,7 +50,7 @@
     }
   ],
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "title": "IDMC GIDD Impacts",
   "extent": {

--- a/examples/idmc-idu-events/idmc-idu-events.json
+++ b/examples/idmc-idu-events/idmc-idu-events.json
@@ -3,7 +3,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "title": "IDMC Internal Displacement Updates (IDU) Impacts",
   "description": "Events from the Internal Displacement Monitoring Centre (IDMC) Internal Displacement Updates (IDU) dataset. The IDU provides near real-time information about displacement events, offering more timely data compared to the annually validated GIDD. Each event includes information about the displacement trigger, affected locations, and temporal details. The IDU data includes source URLs for verification, distinguishes between recommended figures and triangulation, and specifies the accuracy of location information. More information on the IDMC mapping in Monty can be found in the [IDMC IDU Source Mappings](https://github.com/IFRCGo/monty-stac-extension/tree/main/model/sources/IDMC#internal-displacement-updates-idu-items).",

--- a/examples/idmc-idu-impacts/idmc-idu-impact-168623-displaced.json
+++ b/examples/idmc-idu-impacts/idmc-idu-impact-168623-displaced.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "idmc-idu-impact-168623-displaced",
   "geometry": {

--- a/examples/idmc-idu-impacts/idmc-idu-impact-169470-displaced.json
+++ b/examples/idmc-idu-impacts/idmc-idu-impact-169470-displaced.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "id": "idmc-idu-impact-169470-displaced",
   "geometry": {

--- a/examples/idmc-idu-impacts/idmc-idu-impacts.json
+++ b/examples/idmc-idu-impacts/idmc-idu-impacts.json
@@ -3,7 +3,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "title": "IDMC Internal Displacement Updates (IDU) Impacts",
   "description": "Impact records from the Internal Displacement Monitoring Centre (IDMC) Internal Displacement Updates (IDU) dataset. The IDU provides near real-time information about displacement impacts, offering more timely data compared to the annually validated GIDD. Each impact record includes detailed information about the number of displaced persons, the cause of displacement, and the affected locations. The IDU data includes source URLs for verification, distinguishes between recommended figures and triangulation, and specifies the accuracy of location information. More information on the IDMC mapping in Monty can be found in the [IDMC IDU Impact Source Mappings](https://github.com/IFRCGo/monty-stac-extension/tree/main/model/sources/IDMC#idu-impact-details).",

--- a/examples/ifrcevent-events/ifrcevent-events.json
+++ b/examples/ifrcevent-events/ifrcevent-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "ifrcevent-events",

--- a/examples/ifrcevent-hazards/ifrcevent-hazards.json
+++ b/examples/ifrcevent-hazards/ifrcevent-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "ifrcevent-hazards",

--- a/examples/ifrcevent-impacts/ifrcevent-impacts.json
+++ b/examples/ifrcevent-impacts/ifrcevent-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "ifrcevent-impacts",

--- a/examples/pdc-events/pdc-events.json
+++ b/examples/pdc-events/pdc-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "pdc-events",

--- a/examples/pdc-hazards/pdc-hazards.json
+++ b/examples/pdc-hazards/pdc-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "pdc-hazards",

--- a/examples/pdc-impacts/pdc-impacts.json
+++ b/examples/pdc-impacts/pdc-impacts.json
@@ -3,7 +3,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "title": "PDC Impacts",
   "description": "Impact records from the Pacific Disaster Center (PDC). PDC tracks a wide range of natural and human-made hazards and provides detailed impact assessments to support disaster preparedness, response, and risk reduction efforts. The impact records provide comprehensive information about the human and economic consequences of disasters, including affected populations by age group, households, capital losses, and impacts on critical infrastructure such as schools and hospitals. Each impact record is derived from PDC's exposure analysis and includes quantitative measurements with standardized units. More information on the PDC mapping in Monty can be found in the [PDC Impact Source Mappings](https://github.com/IFRCGo/monty-stac-extension/tree/main/model/sources/PDC#impact-item).",

--- a/examples/reference-events/20080512T062800Z-CHN-GEO-SEIS-001-GCDB.json
+++ b/examples/reference-events/20080512T062800Z-CHN-GEO-SEIS-001-GCDB.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20080512T062800Z-CHN-GEO-SEIS-001-GCDB",

--- a/examples/reference-events/20241027T150000-ESP-HM-FLOOD-001-GCDB.json
+++ b/examples/reference-events/20241027T150000-ESP-HM-FLOOD-001-GCDB.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20241027T150000-ESP-HM-FLOOD-001-GCDB",

--- a/examples/reference-events/20250107T010516Z-CHN-GEO-SEIS-001-GCDB.json
+++ b/examples/reference-events/20250107T010516Z-CHN-GEO-SEIS-001-GCDB.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "20250107T010516Z-CHN-GEO-SEIS-001-GCDB",

--- a/examples/reference-events/reference-events.json
+++ b/examples/reference-events/reference-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "reference-events",

--- a/examples/usgs-events/us6000pi9w.json
+++ b/examples/usgs-events/us6000pi9w.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "type": "Feature",

--- a/examples/usgs-events/usgs-events.json
+++ b/examples/usgs-events/usgs-events.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "type": "Collection",

--- a/examples/usgs-hazards/us6000pi9w-shakemap.json
+++ b/examples/usgs-hazards/us6000pi9w-shakemap.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "id": "us6000pi9w-shakemap",

--- a/examples/usgs-hazards/usgs-hazards.json
+++ b/examples/usgs-hazards/usgs-hazards.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "type": "Collection",

--- a/examples/usgs-impacts/us6000pi9w-economic.json
+++ b/examples/usgs-impacts/us6000pi9w-economic.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "id": "us6000pi9w-economic",

--- a/examples/usgs-impacts/us6000pi9w-fatalities.json
+++ b/examples/usgs-impacts/us6000pi9w-fatalities.json
@@ -2,7 +2,7 @@
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "id": "us6000pi9w-fatalities",

--- a/examples/usgs-impacts/usgs-impacts.json
+++ b/examples/usgs-impacts/usgs-impacts.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json",
+    "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json",
     "https://stac-extensions.github.io/earthquake/v1.0.0/schema.json"
   ],
   "type": "Collection",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json#",
+  "$id": "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json#",
   "title": "Monty Extension",
   "description": "STAC Monty Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -94,7 +94,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json"
+            "const": "https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "stac-extension-template",
-  "version": "1.0.0",
+  "name": "monty-stac-extension",
+  "version": "1.1.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml --silently-ignore",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml --silently-ignore",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://ifrcgo.org/monty-stac-extension/v1.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://ifrcgo.org/monty-stac-extension/v1.1.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^12.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "monty-stac-extension"
-version = "1.0.0"
+version = "1.1.0"
 description = "Monty STAC Extension"
 requires-python = ">=3.8"
 


### PR DESCRIPTION
Update all examples and schema files to reference the new version of the Monty STAC Extension.