### PR TITLE
Add monty:response_detail object and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Initial release of the Monty STAC Extension specification.
 - Some features may be subject to change based on community feedback
 - Additional sources may be added in future releases
 
+[Unreleased]: https://github.com/IFRCGo/monty-stac-extension/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.2.0
 [1.1.0]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.1.0
 [1.0.0]: https://github.com/IFRCGo/monty-stac-extension/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `monty:response_detail` object on Response Items with `type` (required, response-taxonomy regex), `source_id`, `status`, `monitoring_number`, `producer`, `methodology`, `sendai_targets`, `sectors`
+- `response` role added to the `roles` `oneOf` branch and to the `typed_related_link.roles` enum (so `rel: related` can target Response items)
+- `related-response` relation type
+- `docs/model/response-best-practices.md` — extension-layering matrix, per-source mapping tables (CEMS, International Charter, UNOSAT), worked snippets, anti-patterns, and linkage summary
+- Response section in `docs/model/README.md` (with updated class diagram) and in `README.md`, including the per-source collection partitioning guidance and the Impact→Response `derived_from` provenance convention
+
 ## [1.2.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The taxonomy of response type codes, the framework survey and the Sendai Framewo
 The extension-layering rules per response type are documented in the [Response Best Practices](https://ifrcgo.org/monty-stac-extension/model/response-best-practices.md).
 
 - Examples:
-  - [UNOSAT damage assessment example](examples/unosat-responses/FL20240926ESP-DA-01.json) — `eo-gra` response item from UNOSAT rapid mapping
+  - TBD
 
 The Response class represents an **action taken or a product produced in response to a disaster** — e.g., a Copernicus EMS Grading map, an International Charter Value-Added Product, a UNOSAT damage assessment, an IFRC DREF operation, or a humanitarian shelter distribution. The scope boundary with Impact is strict: **Response = action / product; Impact = estimated effect on people or assets**. A CEMS Grading Product is a Response that *informs* Impact items; it is not itself an impact.
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ The fields in the sections below can be used in these parts of STAC documents:
 
 ### Item Properties
 
-| Field Name           | Type                                        | Description                                                                                                                                                                                                                                                                                                         |
-| -------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| monty:src_event_id  | string | The identifier of the event in the source system. Used to group all items (event episodes, hazards, impacts) belonging to the same source event, independently of the STAC item `id`. |
-| monty:episode_number | integer                                     | The episode number of the event. It is a unique identifier assigned by the Monty system to the event                                                                                                                                                                                                                |
-| monty:country_codes  | \[string]                                   | **REQUIRED**. The country codes of the countries affected by the event, hazard, impact or response. The country code follows [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) standard format                                                                                                 |
-| monty:corr_id        | string                                      | **REQUIRED**. The unique identifier assigned by the Monty system to the reference event used to "pair" all the items of the same event. The correlation identifier follows a specific convention described in the [event correlation](https://ifrcgo.org/monty-stac-extension/model/correlation_identifier.md) page |
-| monty:hazard_codes   | \[string]                                   | **REQUIRED**. The hazard codes of the hazards affecting the event. For interoperability purpose, the array MUST contain at least one code from a [hazard classification system](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards)                                                                  |
-| monty:hazard_detail  | [Hazard Detail object](#montyhazard_detail) | The details of the hazard                                                                                                                                                                                                                                                                                           |
-| monty:impact_detail  | [Impact Detail object](#montyimpact_detail) | The details of the impact                                                                                                                                                                                                                                                                                           |
-| monty:response_detail | [Response Detail object](#montyresponse_detail) | The details of the response                                                                                                                                                                                                                                                                                       |
+| Field Name            | Type                                            | Description                                                                                                                                                                                                                                                                                                         |
+| --------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| monty:src_event_id    | string                                          | The identifier of the event in the source system. Used to group all items (event episodes, hazards, impacts) belonging to the same source event, independently of the STAC item `id`.                                                                                                                               |
+| monty:episode_number  | integer                                         | The episode number of the event. It is a unique identifier assigned by the Monty system to the event                                                                                                                                                                                                                |
+| monty:country_codes   | \[string]                                       | **REQUIRED**. The country codes of the countries affected by the event, hazard, impact or response. The country code follows [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) standard format                                                                                                 |
+| monty:corr_id         | string                                          | **REQUIRED**. The unique identifier assigned by the Monty system to the reference event used to "pair" all the items of the same event. The correlation identifier follows a specific convention described in the [event correlation](https://ifrcgo.org/monty-stac-extension/model/correlation_identifier.md) page |
+| monty:hazard_codes    | \[string]                                       | **REQUIRED**. The hazard codes of the hazards affecting the event. For interoperability purpose, the array MUST contain at least one code from a [hazard classification system](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards)                                                                  |
+| monty:hazard_detail   | [Hazard Detail object](#montyhazard_detail)     | The details of the hazard                                                                                                                                                                                                                                                                                           |
+| monty:impact_detail   | [Impact Detail object](#montyimpact_detail)     | The details of the impact                                                                                                                                                                                                                                                                                           |
+| monty:response_detail | [Response Detail object](#montyresponse_detail) | The details of the response                                                                                                                                                                                                                                                                                         |
 
 ### Roles
 
@@ -73,12 +73,12 @@ For cross-item relationships represented by `rel="related"` links, the link `rol
 
 ### Link Attributes
 
-| Field Name  | Type      | Description                                                                                                                                          |
-| ----------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Field Name  | Type      | Description                                                                                                                                                        |
+| ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | roles       | \[string] | Semantic classification for the linked entity as an array of strings. For `rel="related"` links between Monty items, use `event`, `hazard`, `impact` or `response` |
-| occ_type    | string    | The type of the occurrence. It can be one of the following values: `known`, `potential`                                                              |
-| occ_prob    | string    | It is a qualitative assessment of the likelihood of the linked hazard occurring with the main hazard (e.g. `high`)                                   |
-| occ_probdef | uri       | It is a link to the definition of the probability for the hazard relationship                                                                        |
+| occ_type    | string    | The type of the occurrence. It can be one of the following values: `known`, `potential`                                                                            |
+| occ_prob    | string    | It is a qualitative assessment of the likelihood of the linked hazard occurring with the main hazard (e.g. `high`)                                                 |
+| occ_probdef | uri       | It is a link to the definition of the probability for the hazard relationship                                                                                      |
 
 #### Additional Field Information
 
@@ -99,7 +99,7 @@ It must at least contain the countries intersected by the item's geometry.
 
 It is a list of hazard codes of the hazards concerned by the item. There are multiple various classification systems for hazards so the field is open to any code.
 
-Nevertheless, the field is recommended to follow at least one of the [referenced classification systems](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards) 
+Nevertheless, the field is recommended to follow at least one of the [referenced classification systems](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards)
 and then to include their other system counterparts following the [crosswalk classification systems mapping](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#cross-classification-mapping) to enforce interoperability.
 
 Tables with the possible values are available in the [hazard section of the taxonomy](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards) with:
@@ -149,7 +149,7 @@ The following defined fields are available in the object:
 | estimate_type  | string | The type of the estimate. The possible values are `primary`, `secondary` and `modelled`                      |
 
 Any other field can be added to the object to provide more details about the hazard.
-For instance, `category` and  `pressure` can be added to provide the category and the pressure of a cyclone.
+For instance, `category` and `pressure` can be added to provide the category and the pressure of a cyclone.
 
 ##### monty:impact_detail
 
@@ -170,16 +170,16 @@ It is an object that contains the details of the response action or product. Pre
 
 The only strictly required field is `type` (the response type code). Other fields are optional and added when the source data supports them. Fields already covered by an STAC extension declared on the same item (e.g., Terradue [`disaster:`](https://github.com/Terradue/stac-extensions-disaster) for International Charter items) **MUST NOT** be duplicated in `monty:response_detail`. See the [Response Best Practices](https://ifrcgo.org/monty-stac-extension/model/response-best-practices.md) document for the per-source extension-layering rules.
 
-| Field Name             | Type      | Description                                                                                                                                                                                                                                                       |
-| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type                   | string    | **REQUIRED** Response type code from the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md) (`{domain}-{type}`, e.g., `eo-del`, `eo-gra`, `hum-shelter`, `fin-dref`)                                                         |
-| source_id              | string    | Source-system identifier for the response (e.g., CEMS activation code `EMSR744`, Charter call id `ACT-849`, DREF operation id)                                                                                                                                    |
-| status                 | string    | Lifecycle status. One of `planned`, `in-production`, `published`, `finished`, `no-impact`, `withdrawn`. Use `disaster:activation_status` instead on items declaring the `disaster:` extension                                                                     |
-| monitoring_number      | integer   | Iteration number for monitoring updates (mirrors CEMS `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a `rel="prev"` link to that Response STAC item                                                  |
-| producer               | string    | Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`)                                                                                                                                                                                 |
-| methodology            | string    | Type of analysis. One of `human_interpreted`, `semi_automated`, `automated`, `modelled`                                                                                                                                                                           |
-| sendai_targets         | \[string] | Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. Defaults per response type are documented in the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md)          |
-| sectors                | \[string] | For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`)                                                                                                                                               |
+| Field Name        | Type      | Description                                                                                                                                                                                                                                                  |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| type              | string    | **REQUIRED** Response type code from the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md) (`{domain}-{type}`, e.g., `eo-del`, `eo-gra`, `hum-shelter`, `fin-dref`)                                                    |
+| source_id         | string    | Source-system identifier for the response (e.g., CEMS activation code `EMSR744`, Charter call id `ACT-849`, DREF operation id)                                                                                                                               |
+| status            | string    | Lifecycle status. One of `planned`, `in-production`, `published`, `finished`, `no-impact`, `withdrawn`. Use `disaster:activation_status` instead on items declaring the `disaster:` extension                                                                |
+| monitoring_number | integer   | Iteration number for monitoring updates (mirrors CEMS `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a `rel="prev"` link to that Response STAC item |
+| producer          | string    | Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`)                                                                                                                                                                            |
+| methodology       | string    | Type of analysis. One of `human_interpreted`, `semi_automated`, `automated`, `modelled`                                                                                                                                                                      |
+| sendai_targets    | \[string] | Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. Defaults per response type are documented in the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md)     |
+| sectors           | \[string] | For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`)                                                                                                                                          |
 
 Statistical / damage figures contained in EO products are **not** part of `response_detail` — they belong to separate Monty Impact items linked via `monty:corr_id`.
 
@@ -188,18 +188,18 @@ Statistical / damage figures contained in EO products are **not** part of `respo
 The following types should be used as applicable `rel` types in the
 [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
 
-| Type                | Description                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Type                | Description                                                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | related             | This link points to another related STAC item. Use link `roles` with exactly one target type: `event`, `hazard`, `impact`, or `response` |
-| reference-event     | This link points to the reference event                                                                            |
-| source-event        | This link points to the source event                                                                               |
-| related-hazard      | This link points to a related hazard. For example, a flood related to the event                                    |
-| related-impact      | This link points to a related impact. For example, a flood related to the impact                                   |
-| related-response    | This link points to a related response. For example, a CEMS Delineation product produced for the event             |
-| triggers-hazard     | This link points to a triggered hazard. For example, an earthquake triggers a landslide                            |
-| triggered-by-hazard | This link points to the hazard that triggered this hazard. For example, an earthquake that triggered a landslide   |
-| concurrent-hazard   | This link points to a concurrent hazard. For example, thunderstorms can occur together with windstorms or cyclones |
-| complex-hazard      | This link points to a complex hazard when the relationship between the hazards is complex                          |
+| reference-event     | This link points to the reference event                                                                                                  |
+| source-event        | This link points to the source event                                                                                                     |
+| related-hazard      | This link points to a related hazard. For example, a flood related to the event                                                          |
+| related-impact      | This link points to a related impact. For example, a flood related to the impact                                                         |
+| related-response    | This link points to a related response. For example, a CEMS Delineation product produced for the event                                   |
+| triggers-hazard     | This link points to a triggered hazard. For example, an earthquake triggers a landslide                                                  |
+| triggered-by-hazard | This link points to the hazard that triggered this hazard. For example, an earthquake that triggered a landslide                         |
+| concurrent-hazard   | This link points to a concurrent hazard. For example, thunderstorms can occur together with windstorms or cyclones                       |
+| complex-hazard      | This link points to a complex hazard when the relationship between the hazards is complex                                                |
 
 ## Event
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The fields in the sections below can be used in these parts of STAC documents:
 | monty:hazard_codes   | \[string]                                   | **REQUIRED**. The hazard codes of the hazards affecting the event. For interoperability purpose, the array MUST contain at least one code from a [hazard classification system](https://ifrcgo.org/monty-stac-extension/model/taxonomy.md#hazards)                                                                  |
 | monty:hazard_detail  | [Hazard Detail object](#montyhazard_detail) | The details of the hazard                                                                                                                                                                                                                                                                                           |
 | monty:impact_detail  | [Impact Detail object](#montyimpact_detail) | The details of the impact                                                                                                                                                                                                                                                                                           |
+| monty:response_detail | [Response Detail object](#montyresponse_detail) | The details of the response                                                                                                                                                                                                                                                                                       |
 
 ### Roles
 
@@ -68,13 +69,13 @@ A set of roles are defined to describe the type of the data. The following roles
 
 The roles are used at the item level in the `roles` field to characterize the data. It is also used in the link object to characterize the linked item.
 
-For cross-item relationships represented by `rel="related"` links, the link `roles` field SHOULD include exactly one target type: `event`, `hazard`, or `impact`.
+For cross-item relationships represented by `rel="related"` links, the link `roles` field SHOULD include exactly one target type: `event`, `hazard`, `impact`, or `response`.
 
 ### Link Attributes
 
 | Field Name  | Type      | Description                                                                                                                                          |
 | ----------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| roles       | \[string] | Semantic classification for the linked entity as an array of strings. For `rel="related"` links between Monty items, use `event`, `hazard` or `impact` |
+| roles       | \[string] | Semantic classification for the linked entity as an array of strings. For `rel="related"` links between Monty items, use `event`, `hazard`, `impact` or `response` |
 | occ_type    | string    | The type of the occurrence. It can be one of the following values: `known`, `potential`                                                              |
 | occ_prob    | string    | It is a qualitative assessment of the likelihood of the linked hazard occurring with the main hazard (e.g. `high`)                                   |
 | occ_probdef | uri       | It is a link to the definition of the probability for the hazard relationship                                                                        |
@@ -163,6 +164,25 @@ It is an object that contains the details of the impact estimate. Preferably use
 | estimate_type | string | The type of the estimate. The possible values are `primary`, `secondary` and `modelled`                                                                                                                                                                       |
 | description   | string | The description of the impact                                                                                                                                                                                                                                 |
 
+##### monty:response_detail
+
+It is an object that contains the details of the response action or product. Preferably used only in a Response item.
+
+The only strictly required field is `type` (the response type code). Other fields are optional and added when the source data supports them. Fields already covered by an STAC extension declared on the same item (e.g., Terradue [`disaster:`](https://github.com/Terradue/stac-extensions-disaster) for International Charter items) **MUST NOT** be duplicated in `monty:response_detail`. See the [Response Best Practices](https://ifrcgo.org/monty-stac-extension/model/response-best-practices.md) document for the per-source extension-layering rules.
+
+| Field Name             | Type      | Description                                                                                                                                                                                                                                                       |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type                   | string    | **REQUIRED** Response type code from the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md) (`{domain}-{type}`, e.g., `eo-del`, `eo-gra`, `hum-shelter`, `fin-dref`)                                                         |
+| source_id              | string    | Source-system identifier for the response (e.g., CEMS activation code `EMSR744`, Charter call id `ACT-849`, DREF operation id)                                                                                                                                    |
+| status                 | string    | Lifecycle status. One of `planned`, `in-production`, `published`, `finished`, `no-impact`, `withdrawn`. Use `disaster:activation_status` instead on items declaring the `disaster:` extension                                                                     |
+| monitoring_number      | integer   | Iteration number for monitoring updates (mirrors CEMS `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a `rel="prev"` link to that Response STAC item                                                  |
+| producer               | string    | Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`)                                                                                                                                                                                 |
+| methodology            | string    | Type of analysis. One of `human_interpreted`, `semi_automated`, `automated`, `modelled`                                                                                                                                                                           |
+| sendai_targets         | \[string] | Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. Defaults per response type are documented in the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md)          |
+| sectors                | \[string] | For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`)                                                                                                                                               |
+
+Statistical / damage figures contained in EO products are **not** part of `response_detail` — they belong to separate Monty Impact items linked via `monty:corr_id`.
+
 ## Relation types
 
 The following types should be used as applicable `rel` types in the
@@ -170,11 +190,12 @@ The following types should be used as applicable `rel` types in the
 
 | Type                | Description                                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| related             | This link points to another related STAC item. Use link `roles` with exactly one target type: `event`, `hazard`, or `impact` |
+| related             | This link points to another related STAC item. Use link `roles` with exactly one target type: `event`, `hazard`, `impact`, or `response` |
 | reference-event     | This link points to the reference event                                                                            |
 | source-event        | This link points to the source event                                                                               |
 | related-hazard      | This link points to a related hazard. For example, a flood related to the event                                    |
 | related-impact      | This link points to a related impact. For example, a flood related to the impact                                   |
+| related-response    | This link points to a related response. For example, a CEMS Delineation product produced for the event             |
 | triggers-hazard     | This link points to a triggered hazard. For example, an earthquake triggers a landslide                            |
 | triggered-by-hazard | This link points to the hazard that triggered this hazard. For example, an earthquake that triggered a landslide   |
 | concurrent-hazard   | This link points to a concurrent hazard. For example, thunderstorms can occur together with windstorms or cyclones |
@@ -276,7 +297,30 @@ An impact object **MUST** have the [`monty:impact_detail`](#montyimpact_detail) 
 
 ### Response
 
-*This section still needs to be defined.*
+This section describes in details the usage of the fields and links for the response object.
+More detail on the field definition is available in the [Montandon model analysis](https://ifrcgo.org/monty-stac-extension/model#response).
+The taxonomy of response type codes, the framework survey and the Sendai Framework crosswalk are documented in the [Response Taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md).
+The extension-layering rules per response type are documented in the [Response Best Practices](https://ifrcgo.org/monty-stac-extension/model/response-best-practices.md).
+
+- Examples:
+  - [UNOSAT damage assessment example](examples/unosat-responses/FL20240926ESP-DA-01.json) — `eo-gra` response item from UNOSAT rapid mapping
+
+The Response class represents an **action taken or a product produced in response to a disaster** — e.g., a Copernicus EMS Grading map, an International Charter Value-Added Product, a UNOSAT damage assessment, an IFRC DREF operation, or a humanitarian shelter distribution. The scope boundary with Impact is strict: **Response = action / product; Impact = estimated effect on people or assets**. A CEMS Grading Product is a Response that *informs* Impact items; it is not itself an impact.
+
+In the Monty model, a Response is **ALWAYS** linked to one or multiple event(s) through `monty:corr_id`. A response item:
+
+- **MUST** include the `response` role in its `roles` field
+- **MUST** include the [`monty:response_detail`](#montyresponse_detail) object with at least the `type` code from the [response taxonomy](https://ifrcgo.org/monty-stac-extension/model/response-taxonomy.md)
+- **SHOULD** include `monty:hazard_codes` indicating which hazard(s) the response addresses
+- **SHOULD** link to the reference event with `reference-event`
+- **SHOULD** link to acquisition / source imagery items via STAC `derived_from` (those acquisition items typically carry `sar:` / `eo:` / `sat:` / `processing:` fields)
+- **SHOULD** link to the source-system product page (e.g., the CEMS activation page, the Charter activation page, the UNOSAT product page) via a STAC `derived_from` link rather than embedding the URL in `monty:response_detail`
+- **MAY** link to Impact items the response informs via `rel: related` with `roles: ["impact"]` (or `related-impact`). The canonical provenance edge is the reverse — each Impact item carries a `rel: derived_from` link back to the Response item it was derived from.
+- **SHOULD** declare any additional STAC extensions whose fields are reused on the item. Fields already covered by an adopted extension **MUST NOT** be duplicated in `monty:response_detail`.
+
+#### Response collection partitioning
+
+Response collections SHOULD be partitioned **per source** (e.g., `cems-responses`, `charter-responses`, `unosat-responses`, `ifrc-dref`) to match upstream catalog boundaries, rather than per response domain (`eo-*`, `hum-*`, `fin-*`). Within a per-source collection, items of multiple response type codes coexist (e.g., a single `cems-responses` collection contains `eo-ref`, `eo-fep`, `eo-del`, `eo-gra`, `eo-sr` items).
 
 ## Contributing
 

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -298,7 +298,7 @@ The Response class has the following attributes:
   - **monitoring_number**: Iteration number for monitoring updates (mirrors the CEMS API `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a STAC `rel="prev"` link to that Response item. **OPTIONAL**
   - **producer**: Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`). **OPTIONAL**
   - **methodology**: Type of analysis — one of `human_interpreted`, `semi_automated`, `automated`, `modelled`. **OPTIONAL**
-  - **sendai_targets**: Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. Default mappings per response type code are documented in the [response taxonomy](response-taxonomy.md#sendai-framework-crosswalk). **OPTIONAL**
+  - **sendai_targets**: Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. See the [response taxonomy](response-taxonomy.md#22-sendai-framework-monitoring) for background on the framework. **OPTIONAL**
   - **sectors**: For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`). **OPTIONAL**
 
 Statistical / damage figures contained in EO products (e.g., CEMS `affected` / `total` per thematic) are **not** part of `response_detail` — they belong to separate Monty Impact items linked via `monty:corr_id`. Likewise, underlying source imagery (acquisition items linked through `derived_from`) carries `sar:` / `eo:` / `sat:` / `processing:` fields directly; those are not copied into `response_detail`.

--- a/docs/model/README.md
+++ b/docs/model/README.md
@@ -92,9 +92,23 @@ classDiagram
     Impact "0..*" --> "1..*" Hazard : is the effect of
 
     class Response {
+        +response_detail: ResponseDetail
     }
 
     Response --|> MontyData
+    Response "0..*" --> "0..*" Hazard : addresses
+    Response "0..*" --> "0..*" Impact : informs
+
+    class ResponseDetail {
+        +type: string
+        +source_id: string
+        +status: string
+        +producer: string
+        +monitoring_number: integer
+        +sendai_targets: string[]
+    }
+
+    ResponseDetail --* Response
     
     class HazardDetail {
         +severity_value: number
@@ -257,3 +271,36 @@ The impact class has the following attributes:
     - Primary data
     - Secondary data
     - Modelled data: estimated without any event-specific data
+
+### Response
+
+Response data represent an **action taken or a product produced in response to a disaster** — for example, a Copernicus EMS Grading map, an International Charter Value-Added Product, a UNOSAT damage assessment, an IFRC DREF operation, or a humanitarian shelter distribution. The scope boundary with Impact is strict: **Response = action / product; Impact = estimated effect on people or assets**. A CEMS Grading Product is a Response that *informs* Impact items; it is not itself an impact.
+
+In the Monty model, a Response is **ALWAYS** linked to one or multiple event(s) through `monty:corr_id`, and SHOULD reference the hazard(s) it addresses (via `monty:hazard_codes` and `related-hazard` links) as well as any acquisition / source imagery items it derives from (via STAC `derived_from` links). The canonical landing page or product URL in the source system (e.g., CEMS activation page, Charter activation page, UNOSAT product page) SHOULD be expressed as a STAC `rel: derived_from` link rather than embedded as a property under `monty:response_detail`. Where the response product informs Impact items, the canonical provenance edge is carried on the **Impact** side: each derived Impact item SHOULD declare a STAC `rel: derived_from` link pointing back to the Response item. The Response item itself MAY add `rel: related` links (with `roles: ["impact"]`) to the Impact items it informs, but those are an optional back-reference — the `derived_from` edge on the Impact item is the authoritative provenance.
+
+The full design rationale, framework survey, taxonomy of response type codes, and Sendai Framework crosswalk are documented in [Response Taxonomy](response-taxonomy.md). The extension-layering rules and worked-example combinations are in [Response Best Practices](response-best-practices.md).
+
+The Response class has the following attributes:
+
+- **id**: A unique identifier for the response. Preferably, the identifier assigned by the issuer (source) of the response (e.g., CEMS activation product code). If not available, an identifier can be generated and should be prefixed with the related event id.
+- **title**: The name of the response assigned by the issuer (source) of the response.
+- **geometry** (GeoJSON geometry): The location / area-of-interest of the response in the form of a GeoJSON geometry.
+- **datetime**: The publication or production date and time of the response.
+- **start_datetime**: The date and time when the response action / product window started. **OPTIONAL**
+- **end_datetime**: The date and time when the response action / product window ended. **OPTIONAL**
+- **ref_event_id**: The identifier of the reference event to which the response is associated.
+- **source_event_id**: The identifier of the source event to which the response is associated. **OPTIONAL**
+- **source**: Information about the organization and the database capturing, producing, processing, hosting or publishing this response data.
+- **response_detail**: A detailed description of the response including:
+  - **type**: **REQUIRED**. The response type code from the [response taxonomy](response-taxonomy.md) (`{domain}-{type}`, e.g., `eo-del`, `eo-gra`, `hum-shelter`, `fin-dref`). The only strictly required field. The domain (`eo`, `hum`, `fin`) is derivable from this prefix.
+  - **source_id**: The native identifier of the response in the source system (CEMS activation code, Charter call id, UNOSAT product code, DREF operation id). **OPTIONAL**
+  - **status**: Lifecycle status — one of `planned`, `in-production`, `published`, `finished`, `no-impact`, `withdrawn`. Harmonises CEMS `statusCode` and Charter `disaster:activation_status`. **OPTIONAL**
+  - **monitoring_number**: Iteration number for monitoring updates (mirrors the CEMS API `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a STAC `rel="prev"` link to that Response item. **OPTIONAL**
+  - **producer**: Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`). **OPTIONAL**
+  - **methodology**: Type of analysis — one of `human_interpreted`, `semi_automated`, `automated`, `modelled`. **OPTIONAL**
+  - **sendai_targets**: Subset of `["A","B","C","D","E","F","G"]` indicating the Sendai Framework targets this response contributes to. Default mappings per response type code are documented in the [response taxonomy](response-taxonomy.md#sendai-framework-crosswalk). **OPTIONAL**
+  - **sectors**: For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`). **OPTIONAL**
+
+Statistical / damage figures contained in EO products (e.g., CEMS `affected` / `total` per thematic) are **not** part of `response_detail` — they belong to separate Monty Impact items linked via `monty:corr_id`. Likewise, underlying source imagery (acquisition items linked through `derived_from`) carries `sar:` / `eo:` / `sat:` / `processing:` fields directly; those are not copied into `response_detail`.
+
+Response items SHOULD declare additional STAC extensions where applicable, rather than duplicating their fields under `monty:response_detail`. The [Response Best Practices](response-best-practices.md) document specifies the recommended extension layering per response type — notably that International Charter VAP items MUST declare the Terradue `disaster:` extension alongside `monty:`.

--- a/docs/model/response-best-practices.md
+++ b/docs/model/response-best-practices.md
@@ -1,0 +1,214 @@
+# Response Best Practices — STAC Extension Combinations
+
+> **Status:** Initial best-practices document accompanying the v1.3 introduction of `monty:response_detail`.
+
+This document specifies which STAC extensions Monty Response items SHOULD or MUST declare, per response type and per source system. The governing principle is **extension layering over duplication**: where a suitable third-party STAC extension exists, Response items declare it alongside `monty:` rather than copying its fields into `monty:response_detail`.
+
+---
+
+## 1. Governing principles
+
+1. **Extension layering over duplication.** When a third-party STAC extension covers a concept (e.g., Terradue `disaster:` for International Charter items, `processing:` for derived EO products, `eo:` / `sar:` / `sat:` for source imagery), Response items SHOULD declare that extension and use its fields directly. Do NOT replicate those fields under `monty:response_detail`.
+2. **Acquisition vs. Response layer separation.** `sat:`, `eo:`, `sar:`, `view:` extensions describe the **acquisition / source imagery** that the Response product is derived from. They apply to the linked acquisition items reached via `derived_from`, **not** to the Response product item itself. A Monty Response item for a CEMS Grading Product is a derived product — its STAC extensions describe its provenance and classification, not the raw imagery.
+3. **`monty:` is always declared.** Every Response item declares the Monty extension and carries at least `monty:response_detail.type`, `monty:corr_id`, `monty:country_codes`, `monty:hazard_codes`, and the `response` role.
+4. **`monty:response_detail` is the residual carrier.** It carries the response type code and Monty-specific metadata that is not already expressed by another declared extension on the same item.
+5. **Statistical figures go to Impact items.** Damage / exposure statistics that EO products may carry (e.g., CEMS `affected` / `total` per thematic) are **not** part of `response_detail` — they belong to separate Monty Impact items linked via `monty:corr_id`.
+
+---
+
+## 2. Extension combinations per response type
+
+| Response type (`monty:response_detail.type`) | Extensions to declare on the Response item | Notes |
+| --- | --- | --- |
+| `eo-ref`, `eo-fep`, `eo-del`, `eo-gra`, `eo-pop`, `eo-mon`, `eo-sr`, `eo-vap` *(CEMS-sourced)* | `monty:` **+** `processing:` *(recommended)* | No CEMS-specific STAC extension exists. CEMS lifecycle fields (`statusCode`, `monitoring`, `monitoringNumber`, `resolutionClass`, `charterNumber`) are carried under `monty:response_detail`. |
+| `eo-ref`, `eo-del`, `eo-gra`, `eo-pop`, `eo-vap` *(International Charter VAPs)* | `monty:` **+** `disaster:` *(MANDATORY)* **+** `processing:` *(recommended)* | Reuse `disaster:class = vap`, `disaster:activation_id`, `disaster:call_ids`, `disaster:activation_status`, `disaster:resolution_class`, `disaster:types`. Do NOT duplicate these under `monty:response_detail`. |
+| `eo-fep`, `eo-del`, `eo-gra`, `eo-pop`, `eo-mon` *(UNOSAT-sourced)* | `monty:` **+** `processing:` *(recommended)* | No UNOSAT STAC extension exists. |
+| `hum-*` *(IFRC / cluster-based humanitarian)* | `monty:` *(only)* | No directly relevant third-party extension. Sectors carried in `monty:response_detail.sectors`. |
+| `fin-*` *(IFRC DREF / EA / AA / PDNA)* | `monty:` *(only)* | Financial-amount fields are not yet part of `monty:response_detail`; tracked as a proposal in the [response taxonomy](response-taxonomy.md) and out of scope for v1. |
+| *(Acquisition / source imagery — linked via `derived_from`)* | `sat:`, `eo:`, `sar:`, `view:`, `disaster:` *(for Charter acquisitions, with `disaster:class = acquisition`)*, `processing:` | These are **not** Monty Response items themselves; they are upstream items referenced by Response items via `rel: derived_from`. |
+
+> The Response item's `stac_extensions` array MUST contain `https://ifrcgo.org/monty-stac-extension/v1.2.0/schema.json` (or newer). The relative ordering of extension URLs is not significant.
+
+---
+
+## 3. Field carriage by source — what goes where
+
+The tables below show which field carries which concept on each source's Response items. Use this to decide whether to populate a `monty:response_detail.*` field or rely on another extension's field on the same item.
+
+### 3.1 CEMS Rapid Mapping
+
+CEMS Response items declare `monty:` (+ optionally `processing:`). They do **not** declare `disaster:`.
+
+| Concept | CEMS API field | Carried on Monty Response item as |
+| --- | --- | --- |
+| Activation code | `code` (e.g., `EMSR744`) | `monty:response_detail.source_id` |
+| Product type | `type` (`REF` / `FEP` / `DEL` / `GRA` / `SR`) | `monty:response_detail.type` (mapped per [taxonomy §4.1](./response-taxonomy.md#eo-response-products)) |
+| Monitoring iteration | `monitoring`, `monitoringNumber` | `monty:response_detail.monitoring_number` (set only on monitoring updates; absent on the initial product) |
+| Product status | `statusCode` (`F` / `N` / `W` / `I`) | `monty:response_detail.status` (mapped: `F→finished`, `N→no-impact`, `W→planned`, `I→in-production`) |
+| Resolution class | `resolutionClass` | Carried on the linked acquisition items (via `eo:gsd` / `sat:` / `disaster:resolution_class` where applicable) — not on the Response item itself |
+| Charter co-activation | `charterNumber` | `rel: related` link (with `roles: ["response"]`) to the corresponding Charter VAP Response item; the Charter VAP item itself carries `disaster:activation_id` |
+| Producer | (provider metadata) | `monty:response_detail.producer` (typically `JRC` or contracted VAP provider) |
+| Methodology | (implicit) | `monty:response_detail.methodology` (typically `human_interpreted` or `semi_automated`) |
+| Sendai targets | — | `monty:response_detail.sendai_targets` (defaults per [taxonomy §4.5](./response-taxonomy.md#sendai-framework-crosswalk)) |
+| Damage statistics | `affected` / `total` per thematic | **NOT** in `response_detail` — emit as separate Monty Impact items linked via `monty:corr_id` |
+
+### 3.2 International Charter
+
+Charter VAP Response items declare `monty:` **+** `disaster:` (+ optionally `processing:`). Fields already covered by `disaster:` MUST be carried on `disaster:` and MUST NOT be duplicated under `monty:response_detail`.
+
+| Concept | Carried on Monty Response item as |
+| --- | --- |
+| Charter object type | `disaster:class = vap` |
+| Activation id | `disaster:activation_id` |
+| Call id(s) | `disaster:call_ids` |
+| Activation status | `disaster:activation_status` |
+| Resolution class | `disaster:resolution_class` |
+| Hazard types | `disaster:types` (and `monty:hazard_codes` for Monty / UNDRR-ISC interoperability) |
+| Country | `disaster:country` (and `monty:country_codes`) |
+| Product type code | `monty:response_detail.type` (best-effort: `eo-del` / `eo-gra` / `eo-pop` / `eo-vap` fallback) |
+| Charter-provided source id | `monty:response_detail.source_id` (e.g., `ACT-849`) |
+| Source landing page | STAC `rel: derived_from` link to the source-system product page (`href` = canonical URL) |
+| Producer (VAP provider) | `monty:response_detail.producer` |
+| Methodology | `monty:response_detail.methodology` |
+
+> **Charter activations themselves** (`disaster:class = activation`) are modelled as Monty **Event** items, not Response items. Only Charter VAPs become Monty Response items.
+
+### 3.3 UNOSAT Rapid Mapping
+
+UNOSAT Response items declare `monty:` (+ optionally `processing:`). No UNOSAT STAC extension exists.
+
+| Concept | UNOSAT field / convention | Carried on Monty Response item as |
+| --- | --- | --- |
+| Product identifier | UNOSAT product code (e.g., `FL20240926ESP`) | `monty:response_detail.source_id` and item `id` |
+| Phase | Phase 0 / 1 / 2 / 3 | Mapped to `monty:response_detail.type` per [taxonomy §4.1](./response-taxonomy.md#eo-response-products) classification guidance (`Phase 1 → eo-fep`, flood extent `→ eo-del`, damage density `→ eo-gra`, population exposure `→ eo-pop`, monitoring `→ eo-mon`) |
+| Producer | (typically `UNOSAT`) | `monty:response_detail.producer` |
+| Methodology | (varies) | `monty:response_detail.methodology` |
+| Sensor / acquisition | Sentinel-1 / Sentinel-2 / ... | Carried on linked acquisition items via `sar:` / `eo:` / `sat:` — **not** on the Response item itself |
+| Resolution class | (varies) | Carried on the linked acquisition items, not on the Response item itself |
+
+---
+
+## 4. Worked extension-stack examples
+
+### 4.1 CEMS Delineation product (`eo-del`)
+
+```jsonc
+{
+  "stac_extensions": [
+    "https://ifrcgo.org/monty-stac-extension/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+  ],
+  "properties": {
+    "monty:response_detail": {
+      "type": "eo-del",
+      "source_id": "EMSR744",
+      "status": "published",
+      "producer": "JRC",
+      "methodology": "human_interpreted",
+      "sendai_targets": ["D", "G"]
+    },
+    "processing:level": "L3",
+    "processing:lineage": "Sentinel-1 GRD → flood-mask classifier → vector cleanup"
+  },
+  "links": [
+    {
+      "rel": "derived_from",
+      "href": "https://emergency.copernicus.eu/mapping/list-of-components/EMSR744",
+      "type": "text/html",
+      "title": "CEMS EMSR744 activation page"
+    }
+  ]
+}
+```
+
+### 4.2 International Charter VAP (`eo-vap`)
+
+```jsonc
+{
+  "stac_extensions": [
+    "https://ifrcgo.org/monty-stac-extension/v1.2.0/schema.json",
+    "https://terradue.github.io/stac-extensions-disaster/v1.1.0/schema.json"
+  ],
+  "properties": {
+    "disaster:class": "vap",
+    "disaster:activation_id": 849,
+    "disaster:call_ids": [1421],
+    "disaster:activation_status": "open",
+    "disaster:resolution_class": "VHR",
+    "disaster:types": ["flood"],
+    "disaster:country": "ESP",
+    "monty:response_detail": {
+      "type": "eo-vap",
+      "source_id": "ACT-849",
+      "producer": "Airbus",
+      "methodology": "human_interpreted",
+      "sendai_targets": ["D", "G"]
+    }
+  },
+  "links": [
+    {
+      "rel": "derived_from",
+      "href": "https://disasterscharter.org/web/guest/activations/-/article/...",
+      "type": "text/html",
+      "title": "International Charter activation ACT-849"
+    }
+  ]
+}
+```
+
+Note the absence of `monty:response_detail.status` — it is carried via `disaster:activation_status` on the same item.
+
+### 4.3 UNOSAT damage assessment (`eo-gra`)
+
+```jsonc
+{
+  "stac_extensions": [
+    "https://ifrcgo.org/monty-stac-extension/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+  ],
+  "properties": {
+    "monty:response_detail": {
+      "type": "eo-gra",
+      "source_id": "FL20240926ESP",
+      "status": "published",
+      "producer": "UNOSAT",
+      "methodology": "human_interpreted",
+      "sendai_targets": ["C", "D"]
+    },
+    "processing:level": "L3",
+    "processing:lineage": "Pleiades VHR optical → manual building damage interpretation"
+  }
+}
+```
+
+---
+
+## 5. Anti-patterns
+
+The following patterns SHOULD be avoided:
+
+- **Duplicating `disaster:` fields under `monty:response_detail`** on Charter items — e.g., adding a parallel `monty:response_detail` field for any concept already covered by `disaster:activation_id`, `disaster:activation_status`, `disaster:resolution_class`, etc. On Charter items declaring `disaster:`, the `disaster:` field is canonical.
+- **Carrying `sar:` / `eo:` / `sat:` fields on the Response product item.** Those describe the source imagery, which lives in separate acquisition items linked via `derived_from`.
+- **Stuffing damage statistics into `response_detail`.** Damage counts, affected populations, building destruction counts MUST become Monty Impact items (separate STAC items, `roles: ["impact"]`) linked to the Response via `monty:corr_id` (and optionally `rel: related` with `roles: ["impact"]`).
+- **Mixing source code into the type code.** Use `eo-del` (source-agnostic) rather than `eo-cems-del` or `eo-charter-del`. Source provenance lives in `monty:response_detail.source_id`, `monty:response_detail.producer`, and `derived_from` links.
+- **Creating multiple `eo-del-mon-N` codes for monitoring iterations.** Use a single `monty:response_detail.monitoring_number = N` field on the monitoring item, mirroring the CEMS API.
+
+---
+
+## 6. Linkage summary
+
+A Monty Response item typically participates in the following links:
+
+| `rel` | Target | `roles` (on link) | Purpose |
+| --- | --- | --- | --- |
+| `self` | this item | — | Standard STAC self link |
+| `collection` | parent collection | — | Standard STAC parent link |
+| `reference-event` | the Monty reference event | — | Ties the response to the canonical Monty event |
+| `source-event` | the source-system event item | — | Ties the response to the source-side event |
+| `related` | another Response item | `["response"]` | Cross-reference to a sibling response (e.g., a CEMS Grading product references a prior Delineation product on the same activation) |
+| `related` | Hazard item(s) | `["hazard"]` | Indicates which hazard(s) the response addresses |
+| `related` | Impact item(s) | `["impact"]` | Optional back-reference to Impact items this response informs. The canonical provenance edge runs the **other way**: each derived Impact item carries a `rel: derived_from` link pointing to this Response item. |
+| `derived_from` | Source-system product page (canonical URL) | — | The Monty Response item is derived from this published source product (e.g., the CEMS activation page, the Charter activation page, the UNOSAT product page). Use this rather than embedding the URL in `monty:response_detail`. |
+| `derived_from` | Acquisition / source imagery item(s) | — | Provenance chain to the raw imagery the response is derived from (those items carry `sat:` / `eo:` / `sar:`) |
+| `prev` | A prior Response item | — | When the current item is a monitoring update of a prior response product (mirrors `monty:response_detail.monitoring_number`) |
+| `via` | Source-system landing page (alternative to `derived_from`) | — | When the source-system endpoint is a generic landing or API URL rather than a published product the Monty item was derived from |

--- a/docs/model/response-best-practices.md
+++ b/docs/model/response-best-practices.md
@@ -1,6 +1,6 @@
 # Response Best Practices — STAC Extension Combinations
 
-> **Status:** Initial best-practices document accompanying the v1.3 introduction of `monty:response_detail`.
+> **Status:** Initial best-practices document accompanying the v1.2 introduction of `monty:response_detail`.
 
 This document specifies which STAC extensions Monty Response items SHOULD or MUST declare, per response type and per source system. The governing principle is **extension layering over duplication**: where a suitable third-party STAC extension exists, Response items declare it alongside `monty:` rather than copying its fields into `monty:response_detail`.
 
@@ -20,7 +20,7 @@ This document specifies which STAC extensions Monty Response items SHOULD or MUS
 
 | Response type (`monty:response_detail.type`) | Extensions to declare on the Response item | Notes |
 | --- | --- | --- |
-| `eo-ref`, `eo-fep`, `eo-del`, `eo-gra`, `eo-pop`, `eo-mon`, `eo-sr`, `eo-vap` *(CEMS-sourced)* | `monty:` **+** `processing:` *(recommended)* | No CEMS-specific STAC extension exists. CEMS lifecycle fields (`statusCode`, `monitoring`, `monitoringNumber`, `resolutionClass`, `charterNumber`) are carried under `monty:response_detail`. |
+| `eo-ref`, `eo-fep`, `eo-del`, `eo-gra`, `eo-pop`, `eo-mon`, `eo-sr`, `eo-vap` *(CEMS-sourced)* | `monty:` **+** `processing:` *(recommended)* | No CEMS-specific STAC extension exists. CEMS `statusCode` and `monitoringNumber` are carried under `monty:response_detail` (as `status` and `monitoring_number`). `resolutionClass` is carried on the linked acquisition items (not on the Response item). `charterNumber` is modelled as a `rel: related` link (with `roles: ["response"]`) to the corresponding Charter VAP Response item. |
 | `eo-ref`, `eo-del`, `eo-gra`, `eo-pop`, `eo-vap` *(International Charter VAPs)* | `monty:` **+** `disaster:` *(MANDATORY)* **+** `processing:` *(recommended)* | Reuse `disaster:class = vap`, `disaster:activation_id`, `disaster:call_ids`, `disaster:activation_status`, `disaster:resolution_class`, `disaster:types`. Do NOT duplicate these under `monty:response_detail`. |
 | `eo-fep`, `eo-del`, `eo-gra`, `eo-pop`, `eo-mon` *(UNOSAT-sourced)* | `monty:` **+** `processing:` *(recommended)* | No UNOSAT STAC extension exists. |
 | `hum-*` *(IFRC / cluster-based humanitarian)* | `monty:` *(only)* | No directly relevant third-party extension. Sectors carried in `monty:response_detail.sectors`. |
@@ -42,14 +42,14 @@ CEMS Response items declare `monty:` (+ optionally `processing:`). They do **not
 | Concept | CEMS API field | Carried on Monty Response item as |
 | --- | --- | --- |
 | Activation code | `code` (e.g., `EMSR744`) | `monty:response_detail.source_id` |
-| Product type | `type` (`REF` / `FEP` / `DEL` / `GRA` / `SR`) | `monty:response_detail.type` (mapped per [taxonomy §4.1](./response-taxonomy.md#eo-response-products)) |
+| Product type | `type` (`REF` / `FEP` / `DEL` / `GRA` / `SR`) | `monty:response_detail.type` (mapped per [taxonomy §4.1](./response-taxonomy.md#41-eo-response-products)) |
 | Monitoring iteration | `monitoring`, `monitoringNumber` | `monty:response_detail.monitoring_number` (set only on monitoring updates; absent on the initial product) |
 | Product status | `statusCode` (`F` / `N` / `W` / `I`) | `monty:response_detail.status` (mapped: `F→finished`, `N→no-impact`, `W→planned`, `I→in-production`) |
 | Resolution class | `resolutionClass` | Carried on the linked acquisition items (via `eo:gsd` / `sat:` / `disaster:resolution_class` where applicable) — not on the Response item itself |
 | Charter co-activation | `charterNumber` | `rel: related` link (with `roles: ["response"]`) to the corresponding Charter VAP Response item; the Charter VAP item itself carries `disaster:activation_id` |
 | Producer | (provider metadata) | `monty:response_detail.producer` (typically `JRC` or contracted VAP provider) |
 | Methodology | (implicit) | `monty:response_detail.methodology` (typically `human_interpreted` or `semi_automated`) |
-| Sendai targets | — | `monty:response_detail.sendai_targets` (defaults per [taxonomy §4.5](./response-taxonomy.md#sendai-framework-crosswalk)) |
+| Sendai targets | — | `monty:response_detail.sendai_targets` (see [taxonomy §2.2](./response-taxonomy.md#22-sendai-framework-monitoring)) |
 | Damage statistics | `affected` / `total` per thematic | **NOT** in `response_detail` — emit as separate Monty Impact items linked via `monty:corr_id` |
 
 ### 3.2 International Charter
@@ -80,7 +80,7 @@ UNOSAT Response items declare `monty:` (+ optionally `processing:`). No UNOSAT S
 | Concept | UNOSAT field / convention | Carried on Monty Response item as |
 | --- | --- | --- |
 | Product identifier | UNOSAT product code (e.g., `FL20240926ESP`) | `monty:response_detail.source_id` and item `id` |
-| Phase | Phase 0 / 1 / 2 / 3 | Mapped to `monty:response_detail.type` per [taxonomy §4.1](./response-taxonomy.md#eo-response-products) classification guidance (`Phase 1 → eo-fep`, flood extent `→ eo-del`, damage density `→ eo-gra`, population exposure `→ eo-pop`, monitoring `→ eo-mon`) |
+| Phase | Phase 0 / 1 / 2 / 3 | Mapped to `monty:response_detail.type` per [taxonomy §4.1](./response-taxonomy.md#41-eo-response-products) classification guidance (`Phase 1 → eo-fep`, flood extent `→ eo-del`, damage density `→ eo-gra`, population exposure `→ eo-pop`, monitoring `→ eo-mon`) |
 | Producer | (typically `UNOSAT`) | `monty:response_detail.producer` |
 | Methodology | (varies) | `monty:response_detail.methodology` |
 | Sensor / acquisition | Sentinel-1 / Sentinel-2 / ... | Carried on linked acquisition items via `sar:` / `eo:` / `sat:` — **not** on the Response item itself |

--- a/docs/model/response-taxonomy.md
+++ b/docs/model/response-taxonomy.md
@@ -1,8 +1,6 @@
 # Response Taxonomy (Working Document — v0.5)
 
 > **Status:** Working document. Framework survey (including existing STAC extensions) and crosswalk are complete; taxonomy structure recommendation and initial code proposals are proposed and pending team review.
->
-> **Relates to:** [developmentseed/esa-montandon#12](https://github.com/developmentseed/esa-montandon/issues/12) · Contributes to D1.1 (KO+4m)
 
 ---
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -165,6 +165,81 @@
           },
           "additionalProperties": true
         },
+        "monty:response_detail": {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "$comment": "Response type code from the Monty response taxonomy (see docs/model/response-taxonomy.md). Format: {domain}-{type} with domain in {eo, hum, fin}.",
+              "pattern": "^(eo|hum|fin)-[a-z0-9]+(-[a-z0-9]+)*$"
+            },
+            "source_id": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Source-system identifier for the response (e.g., CEMS activation code `EMSR744`, Charter call ID `ACT-849`, UNOSAT product code, DREF operation ID)."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "planned",
+                "in-production",
+                "published",
+                "finished",
+                "no-impact",
+                "withdrawn"
+              ],
+              "description": "Lifecycle status of the response product. Harmonises CEMS `statusCode` and Charter `disaster:activation_status`."
+            },
+            "monitoring_number": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Iteration number for monitoring updates (mirrors CEMS `monitoringNumber`). The presence of this field marks the item as a monitoring update. The prior iteration this update monitors SHOULD be expressed via a `rel=\"prev\"` link to that Response STAC item."
+            },
+            "producer": {
+              "type": "string",
+              "description": "Organisation that produced the response (e.g., `JRC`, `UNOSAT`, `Airbus`, `IFRC`)."
+            },
+            "methodology": {
+              "type": "string",
+              "enum": [
+                "human_interpreted",
+                "semi_automated",
+                "automated",
+                "modelled"
+              ],
+              "description": "Type of analysis used to produce the response."
+            },
+            "sendai_targets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "E",
+                  "F",
+                  "G"
+                ]
+              },
+              "uniqueItems": true,
+              "description": "Sendai Framework 2015\u20132030 targets this response contributes to. Defaults per response type are documented in the response taxonomy."
+            },
+            "sectors": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "description": "For humanitarian (`hum-*`) items, the IASC clusters / IFRC EPoA sectors covered (e.g., `shelter`, `health`, `wash`)."
+            }
+          },
+          "additionalProperties": false
+        },
         "monty:impact_detail": {
           "type": "object",
           "properties": {
@@ -339,7 +414,8 @@
                 "enum": [
                   "event",
                   "hazard",
-                  "impact"
+                  "impact",
+                  "response"
                 ]
               }
             }
@@ -385,6 +461,14 @@
           "allOf": [
             {
               "$ref": "#/definitions/is_impact"
+            }
+          ]
+        },
+        {
+          "$comment": "Response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/is_response"
             }
           ]
         }
@@ -470,6 +554,20 @@
           "contains": {
             "const": "impact"
           }
+        }
+      }
+    },
+    "is_response": {
+      "properties": {
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "contains": {
+            "const": "response"
+          }
+        },
+        "monty:response_detail": {
+          "$comment": "Response items SHOULD carry monty:response_detail (validated when present via the field definition)."
         }
       }
     }


### PR DESCRIPTION
### Summary

This PR introduces the Response STAC item schema for the Monty extension. It adds a new `monty:response_detail` property, formalises the `response` role in the schema's `oneOf` branch, and documents how the new field interacts with existing STAC extensions (notably Terradue `disaster:` for International Charter products).

The design intentionally keeps `monty:response_detail` minimal and **non-duplicative**: any concept already covered by an adopted STAC extension on the same item (e.g., `disaster:activation_id`, `disaster:activation_status`, `disaster:resolution_class`, `eo:gsd`, `sat:*`) MUST live on that extension, not under `monty:response_detail`.

### Changes

#### Schema (schema.json)
- New `monty:response_detail` object in `definitions.fields.properties` with `additionalProperties: false`. Fields:
  - `type` *(required, regex `^(eo|hum|fin)-[a-z0-9]+(-[a-z0-9]+)*$`)* — response type code from the response taxonomy.
  - `source_id` — source-system identifier (e.g., CEMS `EMSR744`, Charter `ACT-849`).
  - `status` — lifecycle enum: `planned` | `in-production` | `published` | `finished` | `no-impact` | `withdrawn`.
  - `monitoring_number` *(integer ≥ 1)* — presence of this field marks the item as a monitoring iteration; previous iteration referenced via STAC `rel="prev"`.
  - `producer`, `methodology` *(enum)*, `sendai_targets` *(A–G subset)*, `sectors` *(for `hum-*`)*.
- New `is_response` definition added to the `roles` `oneOf` branch (requires the `response` role).
- New `response` entry added to the `typed_related_link.roles` enum so `rel: related` links can target Response items.

#### Top-level README.md
- New `monty:response_detail` row in the Item Properties table.
- New `monty:response_detail` field-info subsection with the per-field table.
- `response` added to the Roles table.
- `related-response` added to the Relation types table.
- New **Response** section under *Data* describing MUST/SHOULD/MAY linkage rules:
  - **MUST** include the `response` role and `monty:response_detail.type`.
  - **SHOULD** include `monty:hazard_codes` and link to the reference event.
  - **SHOULD** link to acquisition imagery via `derived_from`; **SHOULD** link to the canonical source-system product page via `derived_from` (rather than embedding a URL property).
  - **MAY** add `rel: related` (`roles: ["impact"]`) links to informed Impact items. The canonical provenance edge runs the other way: each Impact item carries a `rel: derived_from` back to its source Response item.
  - **SHOULD** declare any extra extensions (e.g., `disaster:`) instead of duplicating their fields under `monty:response_detail`.
- New **Response collection partitioning** subsection: collections SHOULD be partitioned **per source** (e.g., `cems-responses`, `charter-responses`, `unosat-responses`, `ifrc-dref`) rather than per response domain.

#### Model docs (README.md)
- Class diagram (Mermaid) extended with `ResponseDetail` class and the `Response → Hazard` (`addresses`) and `Response → Impact` (`informs`) associations.
- New **Response** section mirroring the schema field list.
- Updated linkage prose to specify the `derived_from`-from-Impact provenance convention.

#### New doc: response-best-practices.md
- Extension-layering matrix per response type (CEMS, International Charter, UNOSAT, DREF, IFRC EPoA, etc.).
- Per-source mapping tables (source-system fields → `monty:response_detail` / `disaster:` / linked acquisition item).
- Worked extension-stack snippets for `eo-del`, `eo-vap` (`monty:` + `disaster:`), and `eo-gra`.
- Anti-patterns section (e.g., do not embed damage statistics in `response_detail`; emit Impact items instead).
- Linkage summary table (`rel` × target × `roles` × purpose).

### Validation

- `npm test` baseline (61 examples) remains green; no example files were modified by this PR.
- Schema is JSON Schema draft-07-valid (verified with `stac-node-validator`).